### PR TITLE
Step 0 work

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@ int main() {
     quill::Logger *logger = quill::create_logger("RiskTrackingLogger");
     logger->set_log_level(quill::LogLevel::TraceL2);
     // logging setup end
-    
+
     std::vector <Trade> trades;
     trades.push_back(Trade(7, false, 1.4));
     RiskTracker riskTracker(0.0, trades);

--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -16,6 +16,7 @@ int RiskTracker::updateRisk() {
         }
     }
     this->totalRisk += runningSum;
+    this->pendingTrades.clear();
     return 0;
 }
 

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -28,3 +28,13 @@ TEST(TradeRiskTrackerTest, TrackerZeroTest) {
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
 }
+
+TEST(TradeRiskTrackerTest, UpdateRiskTrackerTest) {
+    std::vector<Trade> trackedTrades;
+    RiskTracker riskTracker(0, trackedTrades);
+    riskTracker.addTrade(Trade(44, true, 1.6));
+    riskTracker.addTrade(Trade(44, false, 1.6));
+    riskTracker.updateRisk();
+    EXPECT_TRUE(riskTracker.pendingTrades.empty());
+
+}


### PR DESCRIPTION
What is the purpose of this PR?

I updated the updateRisk function to avoid including previously counted trades by clearing the pendingTrades vector.

What changes did you make? Why?
Cleared the pending trades vector after updating risk.

What bugs did you find while testing?
Trades added to pending trades were being added to total risk every time risk is updated. Risk should only be counted once.

What was the bug you found?
Trades added to pending trades were still considered "pending" even after updating risk, so future updates to risk would still count all the previously pending trades.

How did you address it?
Cleared pending trades vector after updating risk.

What did you struggle with?
Getting started and not putting it off. Also setting up my CMake since it had some issues, but I resolved those.

Is there anything you would change about this step?
N/A